### PR TITLE
Andix instruction

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,11 +10,12 @@ int main()
 	// Here we're assigning values to arbitrary locations to test instruction to register funcitionality
 	HyperScan.ram[10] = 0b0110; // A register
 	HyperScan.ram[11] = 0b0010; // B register
-	HyperScan.ram[12] = 0x0000; // D register
+	HyperScan.ram[12] = 0xFFFFFFFF; // D register
 
 	// if you decode this instruction you'll see it uses the registers set above
 	// we're just assuming PC starts at 0 and the first instruction is at 0 in memory
 	HyperScan.ram[0] = 0x818A2C20; // ANDX D, A, B
+	HyperScan.ram[0] = 0x85937FFE; // ANDIX D, 0xFFFF
 
 	cout << "***HyperScan CPU Test***" << endl;
 
@@ -25,6 +26,18 @@ int main()
 		cout << hex << i;
 		cout << ": ";
 		cout << hex << HyperScan.ram[i];
+		if (i == 10)
+		{
+			cout << "	(A reg)";
+		}
+		else if (i == 11)
+		{
+			cout << "	(B reg)";
+		}
+		else if (i == 12)
+		{
+			cout << "	(D reg)";
+		}
 		cout << endl;
 	}
 
@@ -40,6 +53,18 @@ int main()
 		cout << hex << i;
 		cout << ": ";
 		cout << hex << HyperScan.ram[i];
+		if (i == 10)
+		{
+			cout << "	(A reg)";
+		}
+		else if (i == 11)
+		{
+			cout << "	(B reg)";
+		}
+		else if (i == 12)
+		{
+			cout << "	(D reg)";
+		}
 		cout << endl;
 	}
 

--- a/src/spg290.cpp
+++ b/src/spg290.cpp
@@ -11,12 +11,12 @@ spg290::~spg290()
 {
 }
 
-uint32_t spg290::read(uint32_t a)
+uint32_t spg290::read(uint16_t a)
 {
 	return bus->read(a, false);
 }
 
-void spg290::write(uint32_t a, uint8_t d)
+void spg290::write(uint16_t a, uint32_t d)
 {
 	bus->write(a, d);
 }
@@ -128,7 +128,7 @@ uint8_t spg290::ANDIX()
 	// Extract the immediate value from the instruction word
 	// we have to do the shifting/masking shenanigans because bit 15
 	// of the instruction word falls in the middle of the 16-bit immediate
-	imm == (instr & 0x7FFE) || ((instr & 0x30000) >> 1);
+	imm = ((instr & 0x7FFE) >> 1) | ((instr & 0x30000) >> 2);
 
 	// perform operation
 	d = d & imm;
@@ -140,7 +140,6 @@ uint8_t spg290::ANDIX()
 		// If result is negative number, set N flag bit
 		SetFlag(N, (d >> 31) == 0);
 	}
-
 	// write back the result of the operation
 	write(d_reg, d);
 

--- a/src/spg290.h
+++ b/src/spg290.h
@@ -61,8 +61,8 @@ public:
 private:
 
 	Bus		*bus = nullptr;
-	uint32_t read(uint32_t a);
-	void	write(uint32_t a, uint8_t d);
+	uint32_t read(uint16_t a);
+	void	write(uint16_t a, uint32_t d);
 
 	void	SetFlag(FLAGS290 f, bool v);
 
@@ -92,7 +92,7 @@ private:
 
 	// masks out bits 20-18 of instr which are func3 (for "I-Form" Instructions) 
 	// see page 12 of S+Core7 programmers manual
-	uint8_t		func3_MASK	= 0x1C0000;
+	uint32_t	func3_MASK	= 0x1C0000;
 
 	/* OPCODES */
 	uint8_t ANDX();		// Logical AND	

--- a/src/spg290.h
+++ b/src/spg290.h
@@ -81,12 +81,21 @@ private:
 private:
 	// masks out bits 30-26 of instr which are the opcode
 	uint32_t	OPCODE_MASK	= 0x7C000000;
+
+	// masks out the first bit (CU bit) of instruction
+	// this is used to determine if CPU flags are set or not
+	uint8_t		CU_MASK		= 0x1;
 	
 	// masks out bits 6-1 of instr which are func6 (for "Special-Form" Instructions) 
 	// see page 12 of S+Core7 programmers manual
 	uint8_t		func6_MASK	= 0x7E;
 
+	// masks out bits 20-18 of instr which are func3 (for "I-Form" Instructions) 
+	// see page 12 of S+Core7 programmers manual
+	uint8_t		func3_MASK	= 0x1C0000;
+
 	/* OPCODES */
 	uint8_t ANDX();		// Logical AND	
+	uint8_t ANDIX();	// Logical AND with Immediate
 	uint8_t UNDEF();	// catches undefined opcodes
 };


### PR DESCRIPTION
Implemented ANDIX instruction. Fixed some overarching errors due to improper variable size that were also present in the read and write memory functions. Also added some more test code to main and made the output more legible (kinda).